### PR TITLE
Add scripts for Windows users and a bit more detail and structure to README.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ node_modules
 
 # Editors
 .idea
+output.txt
+test

--- a/README.md
+++ b/README.md
@@ -10,25 +10,31 @@ Copy the .env file into place with
 
 And set your email and password.
 
+
+## Grab on recurrent basis
+
+### Using Node
 After that run the script with the following command:
 
     watch -n 5000 --differences node server.js
 
+### Using Crontab
 Or add it to your crontable:
 
     crontab -e
     
 For the crontab all paths in **MUST** be absolute. 
+
 Within the open cron editor window
 
     0 14 * * * /usr/local/bin/node /Users/<USER_NAME>/<PATH_TO>/grab_packt/server.js >> /tmp/cron_output
+
+
+### using Task Scheduler in Windows
+
+Check out the runt.bat file in the repo. Correct any path if necessary. Try running the script manually to verify that it works as expected. 
 	
-If you are using Windows, create a run.bat file similar to the following:
+Then add a scheduled task to execute run.bat by running.	
 
-	"C:\Program Files\nodejs\node.exe" "C:\Users\<USER_NAME>\Documents\GitHub\grab_packt\server.js" >> "C:\Users\<USER_NAME>\Documents\GitHub\grab_packt\output.txt"
-	
-Then add a scheduled task to execute run.bat daily at noon.	
+    add_scheduled_task.bat
 
-	schtasks.exe /Create /SC DAILY /TN "Grab Packt Books" /TR "C:\Users\<USER_NAME>\Documents\GitHub\grab_packt\run.bat" /ST 12:00
-
-_Make sure you have a output file to write to_

--- a/README.md
+++ b/README.md
@@ -1,17 +1,26 @@
 Grab a book a day for free from Packt Pub, https://www.packtpub.com/packt/offers/free-learning.
 
+## 1. Install prerequisites
+
 Install this script in the cloned directory using the following command:
 
     npm install
+
+
+## 2. Add credentials
 
 Copy the .env file into place with
 
     cp .env.example .env
 
-And set your email and password.
+Or on Windows:
+
+    copy .env.example .env
+
+And set your packt email and password.
 
 
-## Grab on recurrent basis
+## 3. Grab on recurrent basis
 
 ### Using Node
 After that run the script with the following command:
@@ -30,11 +39,11 @@ Within the open cron editor window
     0 14 * * * /usr/local/bin/node /Users/<USER_NAME>/<PATH_TO>/grab_packt/server.js >> /tmp/cron_output
 
 
-### using Task Scheduler in Windows
+### Using Task Scheduler in Windows
 
-Check out the runt.bat file in the repo. Correct any path if necessary. Try running the script manually to verify that it works as expected. 
+Check the *run.bat* file in the repo. Correct any path if necessary according to your needs. Try running the script manually to verify that it works as expected.
 	
-Then add a scheduled task to execute run.bat by running.	
+Then add a scheduled task to execute run.bat every day by running.	
 
     add_scheduled_task.bat
 

--- a/add_scheduled_task.bat
+++ b/add_scheduled_task.bat
@@ -1,0 +1,20 @@
+@echo off
+cls
+
+SET TASKSLIST=taskslist.txt
+SET TASKNAME=Grab_Packt_Books
+
+schtasks.exe /query > %TASKSLIST%
+findstr /B /I %TASKNAME% %TASKSLIST% >nul
+
+IF %errorlevel%==0  GOTO :delete
+GOTO :create
+ 
+:delete
+	echo Removing scheduled task %TASKNAME%
+	schtasks.exe /DELETE /TN "%TASKNAME%" /F >nul
+ 
+:create
+	echo Creating scheduled task %TASKNAME%
+	schtasks.exe /Create /SC DAILY /TN "%TASKNAME%" /TR "C:\Users\%UserName%\Documents\GitHub\grab_packt\run.bat"
+	del "%TASKSLIST%" >nul

--- a/run.bat
+++ b/run.bat
@@ -1,0 +1,1 @@
+"C:\Program Files\nodejs\node.exe" "C:\Users\%UserName%\Documents\GitHub\grab_packt\server.js" >> "C:\Users\%UserName%\Documents\GitHub\grab_packt\output.txt"


### PR DESCRIPTION
New scripts, _run.bat _and _add_scheduled_tasks.bat_, made for windows users to easily get started. The first file, run.bat, is run on a daily basis. If the user is running NodeJS 64-bit and has cloned the repo then nothing has to be changed in this script. By running _add_scheduled_tasks.bat_ a new task is created or recreated in Task Scheduler
