### PR TITLE
Update README.md for More Accurate Crontab Hour

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ Within the open cron editor window
 
     0 14 * * * /usr/local/bin/node /Users/<USER_NAME>/<PATH_TO>/grab_packt/server.js >> /tmp/cron_output
 
+If you are using UTC/BST timezone in your server, you might want to set the crontab as follow:
+
+    25 0 * * * /usr/bin/nodejs /home/user/grab_packt/server.js >> /tmp/cron_output
 
 ### Using Task Scheduler in Windows
 


### PR DESCRIPTION
I think the correct hour in crontab is `25 0 * * *`, if you are using UTC/BST timezone in your server. I have compared `date` output with countdown clock in packt's website, and conclude this solution. 

Here is my crontab settings:
`25 0 * * * /usr/bin/nodejs /home/user/grab_packt/server.js >> /tmp/cron_output`

I have tested this setting and it works well.
